### PR TITLE
makes HashTest inherit from Minitest::Test instead of Minitest::Homework

### DIFF
--- a/core-types/hash_test.rb
+++ b/core-types/hash_test.rb
@@ -2,7 +2,7 @@ gem 'minitest', '~> 5.2'
 require 'minitest/autorun'
 require 'minitest/pride'
 
-class HashTest < Minitest::Homework
+class HashTest < Minitest::Test
   def test_empty
     assert_equal __, {}.empty?
     assert_equal __, {"a" => "apple"}.empty?


### PR DESCRIPTION
fixes #34 

@s-espinosa 