### PR TITLE
Clarified 1 test name and 2 test expected values.

### DIFF
--- a/archive/comparisons/string_comparison_test.rb
+++ b/archive/comparisons/string_comparison_test.rb
@@ -49,7 +49,7 @@ class StringComparisonsTest < Minitest::Test
     maybe s1 >= s2
   end
 
-  def test_the_name_number
+  def test_the_same_number
     skip
     s1 = "1"
     s2 = "1.0"

--- a/problem-solving/test/mad_lib_test.rb
+++ b/problem-solving/test/mad_lib_test.rb
@@ -24,7 +24,7 @@ class MadLibTest < Minitest::Test
     madlib.adjective("purple")
     madlib.adverb("intensely")
     result = madlib.result
-    expected = "Do you walk your blue dog quickly? That's hilarious!"
+    expected = "Do you pet your purple capybara intensely? That's hilarious!"
 
     assert_equal expected, result
   end

--- a/problem-solving/test/retirement_test.rb
+++ b/problem-solving/test/retirement_test.rb
@@ -15,8 +15,8 @@ class RetirementTest < Minitest::Test
   def test_it_tells_me_when_i_should_retire_with_different_ages
     retire = Retirement.new
 
-    result = retire.calculate(25, 65)
-    expected = "You have 40 years left until you can retire. It is 2015, so you can retire in 2055."
+    result = retire.calculate(39, 70)
+    expected = "You have 31 years left until you can retire. It is 2015, so you can retire in 2046."
 
     assert_equal expected, result
   end


### PR DESCRIPTION
Hi, 

Thank you so much for the Turing ruby-exerecises, I have been working through them and they are a terrific resource. Here are a few updates I think would be helpful. This is my first open source pr, please let me know if there is anything I can clarify or should change. 

In the `mad_lib_test.rb`, the `test_it_can_create_a_different_mad_lib` gives new values for the methods but currently expects the same return as the first test. I have updated the expected value:
```ruby
    expected = "Do you walk your blue dog quickly? That's hilarious!"
    expected = "Do you pet your purple capybara intensely? That's hilarious!"
```
In the `retirement_test.rb`, the `test_it_tells_me_when_i_should_retire_with_different_ages` currently gives the same ages and expects the same return as the previous test. I have updated both the provided values and the expected return:

```ruby
    result = retire.calculate(25, 65)
    expected = "You have 40 years left until you can retire. It is 2015, so you can retire in 2055."
    result = retire.calculate(39, 70)
    expected = "You have 31 years left until you can retire. It is 2015, so you can retire in 2046."
```

Lastly, in `string_comparison_test.rb`, there is currently a test titled `test_the_name_number`. This test is designed to test the same number as a float and as an integer, so I have updated the name of the test to `test_the_same_number`.

Thank you so much for maintaining this great resource. 
