### PR TITLE
Add missing skip keyword to final test

### DIFF
--- a/command-query/README.md
+++ b/command-query/README.md
@@ -37,6 +37,7 @@ These exercises focus on these two types of operations.
 - `dog_test.rb`
 - `children_test.rb`
 - `water_test.rb`
+- `clock_test.rb`
 - `appointments_test.rb`
 - `yak_test.rb`
 - `money_test.rb`

--- a/command-query/exercises/money_test.rb
+++ b/command-query/exercises/money_test.rb
@@ -27,8 +27,9 @@ class MoneyTest < Minitest::Test
     money.spend(7)
     assert_equal 31, money.amount
   end
-  
+
   def test_cant_spend_money_that_you_dont_have
+    skip
     money = Money.new
     money.earn(75)
     money.spend(75)

--- a/enumerables/exercises_1/bonus_questions_test.rb
+++ b/enumerables/exercises_1/bonus_questions_test.rb
@@ -65,6 +65,7 @@ class BonusQuestionsTest < Minitest::Test
   end
 
   def test_first_weird_thing_using_find
+    skip
     thing1 = Thing.new('odd')
     thing2 = Thing.new('cool')
     thing3 = Thing.new('weird')
@@ -93,4 +94,3 @@ class BonusQuestionsTest < Minitest::Test
     assert_equal unicorn4, found
   end
 end
-

--- a/enumerables/exercises_2/enumerables_one_test.rb
+++ b/enumerables/exercises_2/enumerables_one_test.rb
@@ -60,3 +60,4 @@ class EnumerablesOneTest < Minitest::Test
     # Your Code Here
     assert_equal ["grn", "shp", "trvl", "lst", "bt"], actual
   end
+end

--- a/iteration/exercises/find_pattern_test.rb
+++ b/iteration/exercises/find_pattern_test.rb
@@ -82,7 +82,6 @@ class FindPatternTest < Minitest::Test
     }
     multiple_of_three = nil
     # Your Code Here
-    end
 
     assert_equal :abdi, multiple_of_three
   end

--- a/iteration/exercises/map_pattern_test.rb
+++ b/iteration/exercises/map_pattern_test.rb
@@ -31,6 +31,7 @@ class MapPatternTest < Minitest::Test
   end
 
   def test_3
+    skip
     numbers = [1, 2, 3, 4, 5]
     doubles = []
     numbers.each do |number|
@@ -40,6 +41,7 @@ class MapPatternTest < Minitest::Test
   end
 
   def test_4
+    skip
     numbers = {
       one: 1,
       two: 2,
@@ -62,6 +64,7 @@ class MapPatternTest < Minitest::Test
   end
 
   def test_5
+    skip
     numbers = [1, 2, 3, 4, 5]
     squares = []
     # Your Code Here
@@ -70,6 +73,7 @@ class MapPatternTest < Minitest::Test
   end
 
   def test_6
+    skip
     numbers = {
       one: 1,
       two: 2,
@@ -91,6 +95,7 @@ class MapPatternTest < Minitest::Test
   end
 
   def test_7
+    skip
     names = ["alice", "bob", "charlie", "david", "eve"]
     #Your Code Here
 
@@ -98,6 +103,7 @@ class MapPatternTest < Minitest::Test
   end
 
   def test_8
+    skip
     family = {
       mother: "alice",
       father: "bob",
@@ -118,6 +124,7 @@ class MapPatternTest < Minitest::Test
   end
 
   def test_9
+    skip
     names = ["alice", "bob", "charlie", "david", "eve"]
     #Your Code Here
 
@@ -125,6 +132,7 @@ class MapPatternTest < Minitest::Test
   end
 
   def test_10
+    skip
     family = {
       mother: "alice",
       father: "bob",
@@ -133,7 +141,7 @@ class MapPatternTest < Minitest::Test
       sister: "eve"
     }
     #Your Code Here
-    
+
     expected = {
       mother: "ecila",
       father: "bob",


### PR DESCRIPTION
Added `skip` keyword which was missing from final test of money_test.rb, `test_cant_spend_money_that_you_dont_have`, and breaking the intended TDD workflow. The file now correctly begins with only the first test not being skipped.