### PR TITLE
Update assert_equal nil to assert_nil()

### DIFF
--- a/enumerables/exercises_1/find_pattern_test.rb
+++ b/enumerables/exercises_1/find_pattern_test.rb
@@ -22,7 +22,7 @@ class FindPatternTest < Minitest::Test
     words.each do |word|
       # Your code goes here
     end
-    assert_equal nil, found
+    assert_nil(found)
   end
 
   def test_find_waldo
@@ -37,7 +37,7 @@ class FindPatternTest < Minitest::Test
     skip
     words = ["piglet", "porridge", "bear", "blueberry"]
     # Your code goes here
-    assert_equal nil, found
+    assert_nil(found)
   end
 
   def test_find_13

--- a/enumerables/exercises_1/find_test.rb
+++ b/enumerables/exercises_1/find_test.rb
@@ -17,7 +17,7 @@ class FindTest < Minitest::Test
     found = words.find do |word|
       # Your code goes here
     end
-    assert_equal nil, found
+    assert_nil(found)
   end
 
   def test_find_waldo
@@ -31,7 +31,7 @@ class FindTest < Minitest::Test
     skip
     words = ["piglet", "porridge", "bear", "blueberry"]
     # Your code goes here
-    assert_equal nil, found
+    assert_nil(found)
   end
 
   def test_find_13

--- a/enumerables/exercises_2/enumerable_exercises_test.rb
+++ b/enumerables/exercises_2/enumerable_exercises_test.rb
@@ -190,13 +190,6 @@ class EnumerablesTest < Minitest::Test
     assert actual
   end
 
-  def test_one_time
-    skip
-    words = ["morning", "time", "evening", "noon", "dusk", "dawn"]
-    actual = # Your code goes here
-    assert actual
-  end
-
   def test_multiply_list_of_numbers
     skip
     numbers = [2, 3, 5, 7]


### PR DESCRIPTION
Minitest warns that `assert_equal nil` is depreciated and recommends using `assert_nil()` for compatibility with Minitest 6