### PR TITLE
Updated require to require_relative and file structure to pull from lib/

### DIFF
--- a/initialize/test/aardvark_test.rb
+++ b/initialize/test/aardvark_test.rb
@@ -1,6 +1,6 @@
 require 'minitest/autorun'
 require 'minitest/pride'
-require './lib/aardvark'
+require_relative '../lib/aardvark'
 
 class AardvarkTest < Minitest::Test
   def test_it_exists

--- a/initialize/test/beaver_test.rb
+++ b/initialize/test/beaver_test.rb
@@ -1,6 +1,6 @@
 require 'minitest/autorun'
 require 'minitest/pride'
-require './lib/beaver'
+require_relative '../lib/beaver'
 
 class BeaverTest < Minitest::Test
   def test_it_exists

--- a/initialize/test/cat_test.rb
+++ b/initialize/test/cat_test.rb
@@ -1,6 +1,6 @@
 require 'minitest/autorun'
 require 'minitest/pride'
-require './lib/cat'
+require_relative '../lib/cat'
 
 class CatTest < Minitest::Test
   def test_it_exists

--- a/initialize/test/dog_test.rb
+++ b/initialize/test/dog_test.rb
@@ -1,6 +1,6 @@
 require 'minitest/autorun'
 require 'minitest/pride'
-require './lib/dog'
+require_relative '../lib/dog'
 
 class DogTest < Minitest::Test
   def test_it_exists

--- a/initialize/test/eel_test.rb
+++ b/initialize/test/eel_test.rb
@@ -1,6 +1,6 @@
 require 'minitest/autorun'
 require 'minitest/pride'
-require './lib/eel'
+require_relative '../lib/eel'
 
 class EelTest < Minitest::Test
   def test_it_exists

--- a/initialize/test/ferret_test.rb
+++ b/initialize/test/ferret_test.rb
@@ -1,6 +1,6 @@
 require 'minitest/autorun'
 require 'minitest/pride'
-require './lib/ferret'
+require_relative '../lib/ferret'
 
 class FerretTest < Minitest::Test
   def test_it_exists

--- a/initialize/test/groundhog_test.rb
+++ b/initialize/test/groundhog_test.rb
@@ -1,6 +1,6 @@
 require 'minitest/autorun'
 require 'minitest/pride'
-require './lib/groundhog'
+require_relative '../lib/groundhog'
 
 class GroundhogTest < Minitest::Test
   def test_it_exists

--- a/initialize/test/horse_test.rb
+++ b/initialize/test/horse_test.rb
@@ -1,6 +1,6 @@
 require 'minitest/autorun'
 require 'minitest/pride'
-require './lib/horse'
+require_relative '../lib/horse'
 
 class HorseTest < Minitest::Test
   def test_it_exists

--- a/initialize/test/iguana_test.rb
+++ b/initialize/test/iguana_test.rb
@@ -1,6 +1,6 @@
 require 'minitest/autorun'
 require 'minitest/pride'
-require './lib/iguana'
+require_relative '../lib/iguana'
 
 class IguanaTest < Minitest::Test
   def test_it_exists

--- a/initialize/test/jackalope_test.rb
+++ b/initialize/test/jackalope_test.rb
@@ -1,6 +1,6 @@
 require 'minitest/autorun'
 require 'minitest/pride'
-require './lib/jackalope'
+require_relative '../lib/jackalope'
 
 class JackalopeTest < Minitest::Test
   def test_it_exists

--- a/initialize/test/kangaroo_test.rb
+++ b/initialize/test/kangaroo_test.rb
@@ -1,6 +1,6 @@
 require 'minitest/autorun'
 require 'minitest/pride'
-require './lib/kangaroo'
+require_relative '../lib/kangaroo'
 
 class KangarooTest < Minitest::Test
   def test_it_exists

--- a/initialize/test/lion_test.rb
+++ b/initialize/test/lion_test.rb
@@ -1,6 +1,6 @@
 require 'minitest/autorun'
 require 'minitest/pride'
-require './lib/lion'
+require_relative '../lib/lion'
 
 class LionTest < Minitest::Test
   def test_it_exists

--- a/initialize/test/monkey_test.rb
+++ b/initialize/test/monkey_test.rb
@@ -1,6 +1,6 @@
 require 'minitest/autorun'
 require 'minitest/pride'
-require './lib/monkey'
+require_relative '../lib/monkey'
 
 class MonkeyTest < Minitest::Test
   def test_it_exists

--- a/initialize/test/narwhal_test.rb
+++ b/initialize/test/narwhal_test.rb
@@ -1,6 +1,6 @@
 require 'minitest/autorun'
 require 'minitest/pride'
-require './lib/narwhal'
+require_relative '../lib/narwhal'
 
 class NarwhalTest < Minitest::Test
   def test_it_exists

--- a/initialize/test/octopus_test.rb
+++ b/initialize/test/octopus_test.rb
@@ -1,8 +1,8 @@
 require 'minitest/autorun'
 require 'minitest/pride'
-require './lib/eel'
-require './lib/narwhal'
-require './lib/octopus'
+require_relative '../lib/eel'
+require_relative '../lib/narwhal'
+require_relative '../lib/octopus'
 
 class OctopusTest < Minitest::Test
   def test_it_exists

--- a/initialize/test/parrot_test.rb
+++ b/initialize/test/parrot_test.rb
@@ -1,6 +1,6 @@
 require 'minitest/autorun'
 require 'minitest/pride'
-require './lib/parrot'
+require_relative '../lib/parrot'
 
 class ParrotTest < Minitest::Test
   def test_it_exists

--- a/initialize/test/quail_test.rb
+++ b/initialize/test/quail_test.rb
@@ -1,6 +1,6 @@
 require 'minitest/autorun'
 require 'minitest/pride'
-require './lib/quail'
+require_relative '../lib/quail'
 
 class QuailTest < Minitest::Test
   def test_it_exists

--- a/initialize/test/rabbit_test.rb
+++ b/initialize/test/rabbit_test.rb
@@ -1,6 +1,6 @@
 require 'minitest/autorun'
 require 'minitest/pride'
-require './lib/rabbit'
+require_relative '../lib/rabbit'
 
 class RabbitTest < Minitest::Test
   def test_it_exists

--- a/initialize/test/snail_test.rb
+++ b/initialize/test/snail_test.rb
@@ -1,6 +1,6 @@
 require 'minitest/autorun'
 require 'minitest/pride'
-require './lib/snail'
+require_relative '../lib/snail'
 
 class SnailTest < Minitest::Test
   def test_it_exists


### PR DESCRIPTION
Within the file ruby-exercises/initialize/test at the top of each of the files it had `require './lib/*NAME*` which would not run so I changed it to `require_relative '../lib/*NAME*` for each of the examples