### PR TITLE
Sigh. NOW it's fixed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Each folder in this repository is a set of related exercises. Open up the folder
   
 If you're new here, watch this getting-started video. We'll install the ruby-exercises directory, figure out how to get set up to practice some `ruby`, and then we'll work through the _complete_ full exercises:
 
-[![Intro to ruby-exercises and strings.rb (YouTube)](/images/embedded-video-screenshot-getting-started.jpg)]((https://youtu.be/aeAkLxr5diE))
+[![Intro to ruby-exercises and strings.rb (YouTube)](/images/embedded-video-screenshot-getting-started.jpg)](https://youtu.be/aeAkLxr5diE)
 
 ## Setup
 

--- a/data-types/strings/README.md
+++ b/data-types/strings/README.md
@@ -21,7 +21,7 @@ There are additional methods that you will need to complete the exercises; each 
 
 [Here's a walk-through to this exercise](https://youtu.be/aeAkLxr5diE). It touches on far more than just the exact solutions to given answers, so please give it a watch, or at least watch a few chunks of it:
 
-[![Intro to ruby-exercises and strings.rb (YouTube)](/images/embedded-video-screenshot-getting-started.jpg)]((https://youtu.be/aeAkLxr5diE))
+[![Intro to ruby-exercises and strings.rb (YouTube)](/images/embedded-video-screenshot-getting-started.jpg)](https://youtu.be/aeAkLxr5diE)
 
 #### What is minitest?
 


### PR DESCRIPTION
Embedding images in Markdown is easy.

Embedding _links_ in markdown is easy.

Embedding images, and making them clickable as links? _hard_

Here's what got me unblocked:

```
[![caption text](/path/to/image.jpg)](https://turing.io)
```

Source: [Creating an image link in Markdown format [duplicate] (StackExchange)](https://meta.stackexchange.com/questions/38915/creating-an-image-link-in-markdown-format)