### PR TITLE
Re-add basic enums test, fix syntax error.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,16 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    byebug (11.1.3)
     coderay (1.1.2)
     method_source (1.0.0)
     minitest (5.2.1)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
+    pry-byebug (3.9.0)
+      byebug (~> 11.0)
+      pry (~> 0.13.0)
 
 PLATFORMS
   ruby
@@ -14,3 +18,5 @@ PLATFORMS
 DEPENDENCIES
   minitest (~> 5.2)
   pry
+  pry-byebug
+

--- a/enumerables/README.md
+++ b/enumerables/README.md
@@ -99,6 +99,6 @@ Here's how we recommend you work through the exercises:
 
 After you are familiar with several enumerables, the exercises in this folder will help you work on your problem solving with enumerables. You will need to select which enumerable will best fit the problem.
 
-For the `enumerables_one_test`, you will only need `map`, `find`, and `find_all` to complete the tasks.
+For the `basic_enumerables_test.rb`, you will only need `map`, `find`, and `find_all` to complete the tasks.
 
-For `enumerables_exercises_test`, you will need to consider all enumerables and pick which one will be the best choice.
+For `all_enumerable_exercises_test.rb`, you will need to consider all enumerables and pick which one will be the best choice.

--- a/enumerables/exercises_2/basic_enumerables_test.rb
+++ b/enumerables/exercises_2/basic_enumerables_test.rb
@@ -1,0 +1,63 @@
+require 'minitest/autorun'
+require 'minitest/pride'
+
+class EnumerablesOneTest < Minitest::Test
+  def test_squares
+    numbers = [1, 2, 3, 4, 5]
+    actual = numbers.map do |number|
+      number ** 2
+    end
+    assert_equal [1, 4, 9, 16, 25], actual
+  end
+
+  def test_find_waldo
+    skip
+    words = ["noise", "dog", "fair", "house", "waldo", "bucket", "fish"]
+    actual = words.find do |word|
+      # Your Code Here
+    end
+    assert_equal "waldo", actual
+  end
+
+  def test_pick_words_with_three_letters
+    skip
+    words = ["pill", "bad", "finger", "cat", "blue", "dog", "table", "red"]
+    actual = # Your Code Here
+    assert_equal ["bad", "cat", "dog", "red"], actual
+  end
+
+  def test_normalize_zip_codes
+    skip
+    numbers = [234, 10, 9119, 38881]
+    # Your Code Here
+    assert_equal ["00234", "00010", "09119", "38881"], actual
+  end
+
+  def test_no_waldo
+    skip
+    words = ["scarf", "sandcastle", "flag", "pretzel", "crow", "key"]
+    # Your Code Here
+    assert_nil found
+  end
+
+  def test_pick_floats
+    skip
+    numbers = [3, 1.4, 3.5, 2, 4.9, 9.1, 8.0]
+    # Your Code Here
+    assert_equal [1.4, 3.5, 4.9, 9.1, 8.0], actual
+  end
+
+  def test_pick_dinosaurs
+    skip
+    animals = ["tyrannosaurus", "narwhal", "eel", "achillesaurus", "qingxiusaurus"]
+    actual = # Your code goes here
+    assert_equal ["tyrannosaurus", "achillesaurus", "qingxiusaurus"], actual
+  end
+
+  def test_words_with_no_vowels
+    skip
+    words = ["green", "sheep", "travel", "least", "boat"]
+    # Your Code Here
+    assert_equal ["grn", "shp", "trvl", "lst", "bt"], actual
+  end
+end


### PR DESCRIPTION
Working through these exercises with a student, I read the last line of the README more carefully:

> For the `basic_enumerables_test.rb`, you will only need `map`, `find`, and `find_all` to complete the tasks.
>
> For `all_enumerable_exercises_test.rb`, you will need to consider all enumerables and pick which one will be the best choice.

(This is the updated language)

Anyway, realized that the file I'd deleted in #72 should be brought back. When I ran it with that PR, it threw a syntax error, and I didn't investigate further. 🤦‍♀️

Anyway, all is fixed now. 