### PR TITLE
Minor edits/corrections in 'enumerables/exercises_1'

### DIFF
--- a/enumerables/exercises_1/reject_pattern_test.rb
+++ b/enumerables/exercises_1/reject_pattern_test.rb
@@ -19,7 +19,7 @@ class RejectPatternTest < Minitest::Test
     letters.each do |letter|
       # Your code goes here
     end
-    assert_equal ["l", "l", " ", "r", " ", "b", "s", " ", "r", " ", "b", "l", "n", "g", " ", "t", " ", "s"], remaining
+    assert_equal ["l", "l", " ", "y", "r", " ", "b", "s", " ", "r", " ", "b", "l", "n", "g", " ", "t", " ", "s"], remaining
   end
 
   def test_remove_numbers_divisible_by_3
@@ -76,7 +76,7 @@ class RejectPatternTest < Minitest::Test
     skip
     elements = ["cat", "dog", 32.333, 23, 56, "aimless", 43.2]
     # Your code goes here
-    assert_equal ["cat", "dog", 23, 56, "aimless"], not_numbers
+    assert_equal ["cat", "dog", 23, 56, "aimless"], not_floats
   end
 
   def test_remove_animals_starting_with_vowels

--- a/enumerables/exercises_1/reject_test.rb
+++ b/enumerables/exercises_1/reject_test.rb
@@ -17,7 +17,7 @@ class RejectTest < Minitest::Test
     remaining = letters.reject do |letter|
       # Your code goes here
     end
-    assert_equal ["l", "l", " ", "r", " ", "b", "s", " ", "r", " ", "b", "l", "n", "g", " ", "t", " ", "s"], remaining
+    assert_equal ["l", "l", " ", "y" "r", " ", "b", "s", " ", "r", " ", "b", "l", "n", "g", " ", "t", " ", "s"], remaining
   end
 
   def test_remove_numbers_divisible_by_3
@@ -73,7 +73,7 @@ class RejectTest < Minitest::Test
     skip
     elements = ["cat", "dog", 32.333, 23, 56, "aimless", 43.2]
     # Your code goes here
-    assert_equal ["cat", "dog", 23, 56, "aimless"], not_numbers
+    assert_equal ["cat", "dog", 23, 56, "aimless"], not_floats
   end
 
   def test_remove_animals_starting_with_vowels


### PR DESCRIPTION
reject_pattern_test.rb
line 22: assert_equal: restored “y” to the assert_equal statement because it is not a vowel
line 77: changed 'not_numbers' to 'not_floats' to accurately match test

reject_test.rb
line 20: assert_equal: restored “y” to the assert_equal statement because it is not a vowel
line 76: changed 'not_numbers' to ‘not_floats' to accurately match test