### PR TITLE
fix variable name error

### DIFF
--- a/initialize/spec/dog_spec.rb
+++ b/initialize/spec/dog_spec.rb
@@ -5,18 +5,18 @@ RSpec.describe Dog do
   it 'exists' do
     doug = Dog.new("Doug", "Golden Retriever")
 
-    expect(dog).to be_an_instance_of(Dog)
+    expect(doug).to be_an_instance_of(Dog)
   end
 
   it 'has a greeting' do
     doug = Dog.new("Doug", "Golden Retriever")
 
-    expect(dog.greeting).to eq("Woof, I'm Doug the Golden Retriever!")
+    expect(doug.greeting).to eq("Woof, I'm Doug the Golden Retriever!")
   end
 
   it 'can have a different greeting' do
     dolly = Dog.new("Dolly", "Lab")
 
-    expect(dog.greeting).to eq("Woof, I'm Dolly the Lab!")
+    expect(dolly.greeting).to eq("Woof, I'm Dolly the Lab!")
   end
 end


### PR DESCRIPTION
This PR:

- Fixes some errors in variable names in `initialize/spec/dog_spec.rb`