### PR TITLE
fix some typos

### DIFF
--- a/command-query/exercises/beers_spec.rb
+++ b/command-query/exercises/beers_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Beers do
     expect(beers.inventory).to eq(98)
 
     53.times { beers.take_one_down_and_pass_it_around }
-    expect(beers.inventory),to eq(45)
+    expect(beers.inventory).to eq(45)
   end
 
   it 'restocks' do

--- a/command-query/exercises/clearance_spec.rb
+++ b/command-query/exercises/clearance_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Clearance do
     # the discount here is a price, so this discount would be 20 percent
     clearance << Item.new('socks', price: 5, discount: 1)
 
-    expect(cleraance.best_deal).to eq('socks')
+    expect(clearance.best_deal).to eq('socks')
   end
 
   it 'has higest percent off many items' do
@@ -25,4 +25,3 @@ RSpec.describe Clearance do
     expect(clearance.best_deal).to eq('pants')
   end
 end
-

--- a/command-query/exercises/cupcakes_spec.rb
+++ b/command-query/exercises/cupcakes_spec.rb
@@ -4,7 +4,7 @@ require_relative 'cupcakes'
 
 RSpec.describe Cupcakes do
   it 'has no sweetest when there are no cupcakes' do
-    cupcakes = Cupcake.new
+    cupcakes = Cupcakes.new
     expect(cupcakes.sweetest).to be_nil
   end
 
@@ -21,6 +21,6 @@ RSpec.describe Cupcakes do
     cupcakes << Cupcake.new('Caramel', 12)
     cupcakes << Cupcake.new('Chocolate', 8)
 
-    expect(cupcakes.sweetest.flavor).to eq('Carrot')
+    expect(cupcakes.sweetest.flavor).to eq('Caramel')
   end
 end

--- a/command-query/exercises/dog_spec.rb
+++ b/command-query/exercises/dog_spec.rb
@@ -8,10 +8,10 @@ RSpec.describe Dog do
     expect(dog.hungry?).to be true
   end
 
-  xit 'eats' do
+  it 'eats' do
     dog = Dog.new
     dog.eat
 
-    expect(dog.hungry).to be false
+    expect(dog.hungry?).to be false
   end
 end

--- a/command-query/exercises/door_spec.rb
+++ b/command-query/exercises/door_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Door do
     expect(door.locked?).to be true
   end
 
-  xit 'unlocks the door' do
+  it 'unlocks the door' do
     door = Door.new
 
     door.unlock

--- a/command-query/exercises/drops_spec.rb
+++ b/command-query/exercises/drops_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Drops do
     expect(drops.count).to eq(0)
   end
 
-  xit 'drips' do
+  it 'drips' do
     drops = Drops.new
     drops.drip
 

--- a/command-query/exercises/floor_spec.rb
+++ b/command-query/exercises/floor_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Floor do
     expect(floor.dirty?).to be true
   end
 
-  xit 'is clean after it is washed' do
+  it 'is clean after it is washed' do
     floor = Floor.new
 
     floor.wash

--- a/command-query/exercises/kid_spec.rb
+++ b/command-query/exercises/kid_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Kid do
     expect(kid.grams_of_sugar_eaten).to eq(0)
   end
 
-  xit 'gets 5 grams from eating candy' do
+  it 'gets 5 grams from eating candy' do
     kid = Kid.new
 
     kid.eat_candy
@@ -20,13 +20,13 @@ RSpec.describe Kid do
     expect(kid.grams_of_sugar_eaten).to eq(30)
   end
 
-  xit 'is not hyperactive' do
+  it 'is not hyperactive' do
     kid = Kid.new
 
     expect(kid.hyperactive?).to be false
   end
 
-  xit 'is hyperactive after 60 grams of sugar' do
+  it 'is hyperactive after 60 grams of sugar' do
     kid = Kid.new
 
     11.times { kid.eat_candy }

--- a/command-query/exercises/leather_chair_spec.rb
+++ b/command-query/exercises/leather_chair_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe LeatherChair do
     expect(chair.faded?).to be false
   end
 
-  xit 'becomes faded when exposed to sunlight' do
+  it 'becomes faded when exposed to sunlight' do
     chair = LeatherChair.new
 
     chair.expose_to_sunlight

--- a/command-query/exercises/milk_bottle_spec.rb
+++ b/command-query/exercises/milk_bottle_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe MilkBottle do
     expect(bottle.full?).to be true
   end
 
-  xit 'spills milk' do
+  it 'spills milk' do
     bottle = MilkBottle.new
 
     bottle.spill

--- a/command-query/exercises/money_spec.rb
+++ b/command-query/exercises/money_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Money do
     expect(money.amount).to eq(0)
   end
 
-  xit 'can earn money' do
+  it 'can earn money' do
     money = Money.new
 
     money.earn(20)
@@ -20,4 +20,3 @@ RSpec.describe Money do
     expect(money.amount).to eq(33)
   end
 end
-

--- a/command-query/exercises/music_spec.rb
+++ b/command-query/exercises/music_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Music do
     expect(music.loud?).to be false
   end
 
-  xit 'is loud after turning up the volume' do
+  it 'is loud after turning up the volume' do
     music = Music.new
 
     music.turn_up

--- a/command-query/exercises/person_spec.rb
+++ b/command-query/exercises/person_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Person do
     expect(person.age).to eq(0)
   end
 
-  xit 'gets older' do
+  it 'gets older' do
     person = Person.new
 
     person.happy_birthday

--- a/command-query/exercises/pills_spec.rb
+++ b/command-query/exercises/pills_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Pills do
     expect(pills.count).to eq(60)
   end
 
-  xit 'it pops a pill' do
+  it 'it pops a pill' do
     pills = Pills.new
 
     pills.pop

--- a/command-query/exercises/roll_call_spec.rb
+++ b/command-query/exercises/roll_call_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe RollCall do
     expect(roll_call.longest_name).to be nil
   end
 
-  xit 'has a longest of one' do
+  it 'has a longest of one' do
     roll_call = RollCall.new
 
     roll_call << 'Oda'
@@ -15,7 +15,7 @@ RSpec.describe RollCall do
     expect(roll_call.longest_name).to eq('Oda')
   end
 
-  xit 'has longest of several' do
+  it 'has longest of several' do
     roll_call = RollCall.new
     roll_call << "Ann"
     roll_call << "Alexandra"

--- a/command-query/exercises/santa_spec.rb
+++ b/command-query/exercises/santa_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Santa do
     expect(santa.fits?).to be true
   end
 
-  xit 'does not fit down the chimney if he eats too many cookies' do
+  it 'does not fit down the chimney if he eats too many cookies' do
     santa = Santa.new
     santa.eats_cookies
 

--- a/command-query/exercises/student_spec.rb
+++ b/command-query/exercises/student_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Student do
     expect(student.grade).to eq('C')
   end
 
-  xit 'can improve its grade' do
+  it 'can improve its grade' do
     student = Student.new
 
     student.study
@@ -18,7 +18,7 @@ RSpec.describe Student do
     expect(student.grade).to eq('A')
   end
 
-  xit 'can only get so good' do
+  it 'can only get so good' do
     student = Student.new
 
     3.times { student.study }
@@ -26,24 +26,24 @@ RSpec.describe Student do
     expect(student.grade).to eq('A')
   end
 
-  xit 'can get worse' do
+  it 'can get worse' do
     student = Student.new
 
     student.slack_off
     expect(student.grade).to eq('D')
 
     student.slack_off
-    expect(student.grade).to eq('F')
+    expect(student.grade).to eq('E')
   end
 
-  xit 'can only get so worse' do
+  it 'can only get so worse' do
     student = Student.new
 
     100.times { student.slack_off }
     expect(student.grade).to eq('F')
   end
 
-  xit 'slacking off is immediately noticable' do
+  it 'slacking off is immediately noticable' do
     student = Student.new
 
     100.times { student.study }
@@ -52,14 +52,13 @@ RSpec.describe Student do
     expect(student.grade).to eq('B')
   end
 
-  xit 'however, so is studying' do
+  it 'however, so is studying' do
     student = Student.new
 
     100.times { student.slack_off }
-    student.slack_off
+    student.study
 
-    expect(student.grade).to eq('B')
+    expect(student.grade).to eq('E')
 
   end
 end
-

--- a/command-query/exercises/teeth_spec.rb
+++ b/command-query/exercises/teeth_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Teeth do
     expect(teeth.clean?).to be false
   end
 
-  xit 'are clean after brushing them' do
+  it 'are clean after brushing them' do
     teeth = Teeth.new
 
     teeth.brush

--- a/command-query/exercises/tire_spec.rb
+++ b/command-query/exercises/tire_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Tire do
     expect(tire.flat?).to be false
   end
 
-  xit 'can have a blowout' do
+  it 'can have a blowout' do
     tire = Tire.new
 
     tire.blow_out
@@ -16,4 +16,3 @@ RSpec.describe Tire do
   end
 
 end
-

--- a/command-query/exercises/wallet_spec.rb
+++ b/command-query/exercises/wallet_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Wallet do
     expect(wallet.cents).to eq(0)
   end
 
-  xit 'can add pennies' do
+  it 'can add pennies' do
     wallet = Wallet.new
 
     wallet << :penny
@@ -18,7 +18,7 @@ RSpec.describe Wallet do
     expect(wallet.cents).to eq(4)
   end
 
-  xit 'can add nickels' do
+  it 'can add nickels' do
     wallet = Wallet.new
 
     wallet << :nickel
@@ -28,7 +28,7 @@ RSpec.describe Wallet do
     expect(wallet.cents).to eq(20)
   end
 
-  xit 'can add dimes' do
+  it 'can add dimes' do
     wallet = Wallet.new
 
     wallet << :dime
@@ -38,7 +38,7 @@ RSpec.describe Wallet do
     expect(wallet.cents).to eq(40)
   end
 
-  xit 'can add quarters' do
+  it 'can add quarters' do
     wallet = Wallet.new
 
     wallet << :quarter
@@ -48,7 +48,7 @@ RSpec.describe Wallet do
     expect(wallet.cents).to eq(100)
   end
 
-  xit 'can take coins out' do
+  it 'can take coins out' do
     wallet = Wallet.new
     wallet << :penny
     wallet << :penny
@@ -62,7 +62,7 @@ RSpec.describe Wallet do
     expect(wallet.cents).to eq(1)
   end
 
-  xit 'can taake various coins out' do
+  it 'can taake various coins out' do
     wallet = Wallet.new
     wallet << :penny
     wallet << :dime
@@ -73,10 +73,11 @@ RSpec.describe Wallet do
     expect(wallet.cents).to eq(26)
   end
 
-  xit 'ignores coins that arent there' do
+  it 'ignores coins that arent there' do
     wallet = Wallet.new
     wallet << :penny
     wallet.take(:dime)
 
     expect(wallet.cents).to eq(1)
   end
+end

--- a/command-query/exercises/water_spec.rb
+++ b/command-query/exercises/water_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Water do
     expect(water.temperature).to eq(295) # Measured in Kelvin
   end
 
-  xit 'can be heated' do
+  it 'can be heated' do
     water = Water.new
 
     water.heat

--- a/command-query/exercises/yak_spec.rb
+++ b/command-query/exercises/yak_spec.rb
@@ -5,10 +5,10 @@ RSpec.describe Yak do
   it 'is hairy' do
     yak = Yak.new
 
-    expect(yak.hairy).to be true
+    expect(yak.hairy?).to be true
   end
 
-  xit 'can be shaved' do
+  it 'can be shaved' do
     yak = Yak.new
 
     yak.shave


### PR DESCRIPTION
```beers_spec``` 
	- typo (line 18) - should be a period instead of a comma

```clearance_spec``` 
	- typo (line 16) - should be ```clearance``` instead of ```cleraance```

```cupcakes_spec``` 
	- typo (line 7) - should be ```Cupcakes``` instead of ```Cupcake```
	- wrong expectation (line 24) should be ```Caramel``` instead of ```Carrot``` because caramel cupcake has the largest amount of sugar

```dog_spec```
	- typo (line 15) should be ```hungry?``` instead of ```hungry```
	
```student_spec```
	- typo (line 36) should be ```E``` instead of ```F``` because slack_off decreases the grade only by one step
	- typo (line 59) should be ```.study``` instead of ```.slack_off``` since the 'it' block is already testing the ```.study``` method
	- typo (line 61) should be ```E``` instead of ```B``` since the grade will be stuck on ```F``` because of invoking slack_off multiple times and studying will only increase the grade by one level

```yak_spec```
	- type (line 8) should be ```.hairy?``` instead of ```.hairy```. line 16 has .hairy? method but line 8 has no question mark. preferred w/ ? instead since method returns a boolean

removed ```xit``` for the following spec files
- dog_spec
- door_spec
- drops_spec
- floor_spec
- kid_spec
- leather_chair_spec
- milk_bottle_spec
- money_spec
- music_spec	
- person_spec
- pills_spec
- roll_call_spec
- santa_spec
- student_spec
- teeth_spec
- tire_spec
- wallet_spec
- water_spec
- yak_spec